### PR TITLE
Changes neccessary to use Continuous trajectory, also small details to get script running

### DIFF
--- a/required_data/config_files/GOMC_GCMC.conf
+++ b/required_data/config_files/GOMC_GCMC.conf
@@ -86,6 +86,7 @@ PressureCalc	true	GOMC_console_BLKavg_Hist_Steps
 ################################
 # STEPS   (DO NOT MODIFY or the hybrid simulation and combine files may not work) 
 ################################
+InitStep		0
 RunSteps		GOMC_Run_Steps
 EqSteps			GOMC_Equilb_Steps
 AdjSteps		GOMC_Adj_Steps 

--- a/required_data/config_files/GOMC_GEMC.conf
+++ b/required_data/config_files/GOMC_GEMC.conf
@@ -87,6 +87,7 @@ PressureCalc  true GOMC_console_BLKavg_Hist_Steps
 ################################
 # STEPS   (DO NOT MODIFY or the hybrid simulation and combine files may not work) 
 ################################
+InitStep		0
 RunSteps         GOMC_Run_Steps
 EqSteps 		GOMC_Equilb_Steps
 AdjSteps	   	GOMC_Adj_Steps 

--- a/required_data/config_files/GOMC_NPT.conf
+++ b/required_data/config_files/GOMC_NPT.conf
@@ -82,6 +82,7 @@ PressureCalc  true GOMC_console_BLKavg_Hist_Steps
 ################################
 # STEPS   (DO NOT MODIFY or the hybrid simulation and combine files may not work) 
 ################################
+InitStep		0
 RunSteps         GOMC_Run_Steps
 EqSteps 		GOMC_Equilb_Steps
 AdjSteps	   	GOMC_Adj_Steps 

--- a/required_data/config_files/GOMC_NVT.conf
+++ b/required_data/config_files/GOMC_NVT.conf
@@ -81,6 +81,7 @@ PressureCalc  true GOMC_console_BLKavg_Hist_Steps
 ################################
 # STEPS  (DO NOT MODIFY or the hybrid simulation and combine files may not work) 
 ################################
+InitStep		0
 RunSteps         GOMC_Run_Steps
 EqSteps 		GOMC_Equilb_Steps
 AdjSteps	   	GOMC_Adj_Steps 

--- a/run_NAMD_GOMC.py
+++ b/run_NAMD_GOMC.py
@@ -82,8 +82,8 @@ manual_testing_filename_input_override = False
 if json_filename is None and manual_testing_filename_input_override is True:
     json_filename = "user_input_NAMD_GOMC.json"
 
-json_file_data = json.load(open(json_filename))
-#json_file_data = json.load(open("user_input_NAMD_GOMC.json"))
+#json_file_data = json.load(open(json_filename))
+json_file_data = json.load(open("user_input_NAMD_GOMC.json"))
 json_file_data_keys_list = json_file_data.keys()
 # get the total_cycles_namd_gomc_sims variable from the json file
 if "total_cycles_namd_gomc_sims" not in json_file_data_keys_list:

--- a/user_input_NAMD_GOMC.json
+++ b/user_input_NAMD_GOMC.json
@@ -1,6 +1,6 @@
 {"total_cycles_namd_gomc_sims": 10,
 "starting_at_cycle_namd_gomc_sims": 0,
-"gomc_use_CPU_or_GPU": "GPU" ,
+"gomc_use_CPU_or_GPU": "CPU" ,
 "simulation_type": "GCMC",
 "only_use_box_0_for_namd_for_gemc": false,
 "no_core_box_0": 8,


### PR DESCRIPTION
Should be merged concurrently with https://github.com/GOMC-WSU/GOMC/pull/374

Added "InitStep 0" to GOMC conf files.  

Modified user_input so there is consistency between chosen ensemble ( was GPU ) and the name of the binary run (was CPU) now both was CPU.  

Finally, the user defined input file functionality isn't working for me so I commented it out and used the hardcoded filename.

I ran the neon sphere for 5 cycles, the frameshots and trajectories are attached below.